### PR TITLE
Do not remove wrapping quotes

### DIFF
--- a/src/main/java/pipetableformatter/ColumnSplitter.java
+++ b/src/main/java/pipetableformatter/ColumnSplitter.java
@@ -11,7 +11,6 @@ public class ColumnSplitter implements Iterable<String>, Iterator<String> {
     private int startIndex = 0;
     private int length = 0;
     private boolean insideQuoted = false;
-    private boolean quoted = false;
     private Character delimiter;
     private int prevStartIndex;
     private int columnIndex;
@@ -62,7 +61,7 @@ public class ColumnSplitter implements Iterable<String>, Iterator<String> {
         prevStartIndex = startIndex;
         startIndex = endIndex + 1;
         columnIndex++;
-        return openQuotes(value);
+        return value;
     }
 
     private boolean hasMoreChars(int endIndex) {
@@ -75,26 +74,8 @@ public class ColumnSplitter implements Iterable<String>, Iterator<String> {
 
     private void detectQuoted(int index) {
         if (line.charAt(index) == '"') {
-            quoted = true;
             insideQuoted = !insideQuoted;
         }
-    }
-
-    private String openQuotes(String value) {
-        if (quoted) {
-            quoted = false;
-            return replaceTwoQuotesWithOne(removeOpenAndCloseQuotes(value));
-        } else {
-            return value;
-        }
-    }
-
-    private String replaceTwoQuotesWithOne(String value) {
-        return value.replaceAll("\"\"", "\"");
-    }
-
-    private String removeOpenAndCloseQuotes(String value) {
-        return value.replaceAll("(^ *\")|(\" *$)", "");
     }
 
     public int currentColumnStartIndex() {
@@ -128,7 +109,7 @@ public class ColumnSplitter implements Iterable<String>, Iterator<String> {
         return leadingSpaces;
     }
     
-    public String getIndentetion() {
+    public String getIndentation() {
         if(leadingSpaces > 0) {
             return String.format("%" + leadingSpaces + "s", " ");
         } else {

--- a/src/main/java/pipetableformatter/PipeTableParser.java
+++ b/src/main/java/pipetableformatter/PipeTableParser.java
@@ -93,7 +93,7 @@ public class PipeTableParser {
         
         PipeTable.Row row = new PipeTable.Row(cells, endOfLine);
         row.setCommented(tableRow.isCommented());
-        row.setIndentation(tableRow.getIndentetion());
+        row.setIndentation(tableRow.getIndentation());
         row.setLeadingPipe(tableRow.hasLeadingPipe());
         row.setTrailingPipe(tableRow.hasTrailingPipe());
         

--- a/src/test/java/pipetableformatter/PipeTableParserTest.java
+++ b/src/test/java/pipetableformatter/PipeTableParserTest.java
@@ -77,21 +77,21 @@ public class PipeTableParserTest {
     @Test
     public void ignoresCommasInsideDoubleQuotes() {
         PipeTable pipeTable = new PipeTableParser(" \"col1val1,col1val2\",column2").parse();
-        assertThat(pipeTable.getValue(0, 0), is("col1val1,col1val2"));
+        assertThat(pipeTable.getValue(0, 0), is("\"col1val1,col1val2\""));
         assertThat(pipeTable.getValue(0, 1), is("column2"));
     }
 
     @Test
     public void ignoresPipeInsideDoubleQuotes() {
         PipeTable pipeTable = new PipeTableParser(" |\"col1val1|col1val2\"|column2|").parse();
-        assertThat(pipeTable.getValue(0, 0), is("col1val1|col1val2"));
+        assertThat(pipeTable.getValue(0, 0), is("\"col1val1|col1val2\""));
         assertThat(pipeTable.getValue(0, 1), is("column2"));
     }
 
     @Test
     public void treatsTwoDoubleQuotesInsideQuotesAsOne() {
         PipeTable pipeTable = new PipeTableParser(" |\"val1\"\"val2\"|column2|").parse();
-        assertThat(pipeTable.getValue(0, 0), is("val1\"val2"));
+        assertThat(pipeTable.getValue(0, 0), is("\"val1\"\"val2\""));
     }
 
     @Test


### PR DESCRIPTION
Hi @anton-dev-ua , thank you for this plugin, it's making my life so much easier!

I ran into the issue where running the plugin successive times effectively changes the content of cells, and that has caused me trouble running it multiple times (`""a value""` becomes `"a value"` and then becomes `a value`). I think a formatting plugin should not alter the values if it can, as registered by somebody else in https://github.com/anton-dev-ua/PipeTableFormatter/issues/11

Here's a proposal for this, I figured I might as well contribute it back so everybody can benefit. I haven't touched the xml file on purpose since I'd like to see if you have reasons for it to behave the current way 😄 

Thanks!